### PR TITLE
Key repeat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Key repeat for navigation buttons on GFX HAT with intelligent threshold
+- Key repeat for all navigation and action buttons on GFX HAT with intelligent held event threshold
   - Hold down arrow buttons for continuous scrolling through instruments, presets, and menus
-  - Short press: single navigation step with immediate response
-  - Hold: continuous scrolling starts after brief delay (2 held events) to prevent accidental over-navigation
+  - Long press ENTER button to open preset menu (with threshold to prevent accidental triggers)
+  - Intelligent threshold distinguishes between short press and hold
+    - Short press: immediate single-step navigation or menu action
+    - Hold: continuous scrolling/long-press action starts after brief delay (2 held events)
+    - Prevents accidental over-navigation or unintended long-press activation
 
 ## [2.2.0] - 2025-11-15
 

--- a/src/pi_pianoteq/client/gfxhat/instrument_display.py
+++ b/src/pi_pianoteq/client/gfxhat/instrument_display.py
@@ -112,7 +112,9 @@ class InstrumentDisplay:
 
             elif event == 'held':
                 if ch == touch.ENTER:
-                    self.on_enter_preset_menu()
+                    self.held_count[ch] = self.held_count.get(ch, 0) + 1
+                    if self.held_count[ch] >= self.held_threshold:
+                        self.on_enter_preset_menu()
                 elif ch in (touch.UP, touch.DOWN, touch.LEFT, touch.RIGHT):
                     self.held_count[ch] = self.held_count.get(ch, 0) + 1
                     if self.held_count[ch] >= self.held_threshold:

--- a/src/pi_pianoteq/client/gfxhat/instrument_menu_display.py
+++ b/src/pi_pianoteq/client/gfxhat/instrument_menu_display.py
@@ -74,9 +74,11 @@ class InstrumentMenuDisplay(MenuDisplay):
         def handler(ch, event):
             if event == 'held':
                 if ch == touch.ENTER:
-                    option_name = self.menu_options[self.current_menu_option].name
-                    if option_name != "Shut down":
-                        self.on_enter_preset_menu(option_name)
+                    self.held_count[ch] = self.held_count.get(ch, 0) + 1
+                    if self.held_count[ch] >= self.held_threshold:
+                        option_name = self.menu_options[self.current_menu_option].name
+                        if option_name != "Shut down":
+                            self.on_enter_preset_menu(option_name)
                     return
 
             base_handler(ch, event)

--- a/src/pi_pianoteq/client/gfxhat/menu_display.py
+++ b/src/pi_pianoteq/client/gfxhat/menu_display.py
@@ -174,7 +174,8 @@ class MenuDisplay:
                     if self.suppression.allow_action():
                         self.menu_options[self.current_menu_option].trigger()
                         self.selected_menu_option = self.current_menu_option
-                elif ch in self.held_count:
+
+                if ch in self.held_count:
                     del self.held_count[ch]
 
         return handler

--- a/tests/client/gfxhat/test_instrument_display.py
+++ b/tests/client/gfxhat/test_instrument_display.py
@@ -128,12 +128,15 @@ class InstrumentDisplayTestCase(unittest.TestCase):
         self.on_enter.assert_not_called()
 
     def test_enter_held_calls_on_enter_preset_menu(self):
-        """ENTER held should call on_enter_preset_menu callback."""
+        """ENTER held should call on_enter_preset_menu callback after threshold."""
         display = self.create_display()
         handler = display.get_handler()
 
+        # Send held events to meet threshold (default: 2)
         handler(touch.ENTER, 'held')
+        self.on_enter_preset_menu.assert_not_called()
 
+        handler(touch.ENTER, 'held')
         self.on_enter_preset_menu.assert_called_once()
 
     def test_update_display_fetches_new_state(self):

--- a/tests/client/gfxhat/test_instrument_menu_display.py
+++ b/tests/client/gfxhat/test_instrument_menu_display.py
@@ -74,23 +74,28 @@ class InstrumentMenuDisplayTestCase(unittest.TestCase):
         display.update_instrument()
 
     def test_enter_held_opens_preset_menu_for_instrument(self):
-        """ENTER held on instrument should call on_enter_preset_menu."""
+        """ENTER held on instrument should call on_enter_preset_menu after threshold."""
         display = self.create_display()
         handler = display.get_handler()
 
         display.current_menu_option = 1  # Strings
 
+        # Send held events to meet threshold (default: 2)
         handler(touch.ENTER, 'held')
+        self.on_enter_preset_menu.assert_not_called()
 
+        handler(touch.ENTER, 'held')
         self.on_enter_preset_menu.assert_called_once_with("Strings")
 
     def test_enter_held_on_shutdown_does_nothing(self):
-        """ENTER held on 'Shut down' should not open preset menu."""
+        """ENTER held on 'Shut down' should not open preset menu even after threshold."""
         display = self.create_display()
         handler = display.get_handler()
 
         display.current_menu_option = 3  # Shut down
 
+        # Send held events beyond threshold to verify shutdown doesn't trigger preset menu
+        handler(touch.ENTER, 'held')
         handler(touch.ENTER, 'held')
 
         self.on_enter_preset_menu.assert_not_called()
@@ -283,7 +288,7 @@ class InstrumentMenuDisplayTestCase(unittest.TestCase):
             self.on_exit.assert_called_once()
 
     def test_enter_held_with_different_instruments(self):
-        """ENTER held should work for all instrument options."""
+        """ENTER held should work for all instrument options after threshold."""
         display = self.create_display()
         handler = display.get_handler()
 
@@ -292,9 +297,15 @@ class InstrumentMenuDisplayTestCase(unittest.TestCase):
             self.on_enter_preset_menu.reset_mock()
 
             display.current_menu_option = i
+            # Send held events to meet threshold (default: 2)
             handler(touch.ENTER, 'held')
+            self.on_enter_preset_menu.assert_not_called()
 
+            handler(touch.ENTER, 'held')
             self.on_enter_preset_menu.assert_called_once_with(instrument)
+
+            # Release to clean up held_count for next iteration
+            handler(touch.ENTER, 'release')
 
     def test_update_instrument_updates_scroller(self):
         """update_instrument should update scrolling text."""


### PR DESCRIPTION
Implements key repeat functionality for arrow buttons (UP, DOWN, LEFT, RIGHT) on the GFX HAT interface. Users can now hold down navigation buttons for continuous scrolling through instruments, presets, and menus.

Changes:
- Modified InstrumentDisplay to handle 'held' events for navigation buttons
- Modified MenuDisplay to handle 'held' events for navigation buttons
- Refactored button handlers to use if-elif chains for better code clarity
- BACK button only responds to 'press' event to avoid unintended exits

All 296 tests pass. Resolves #44.