### PR TITLE
Client discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- `--cli` flag removed: Use `--client cli` instead
+  - Old: `pi-pianoteq --cli`
+  - New: `pi-pianoteq --client cli`
+  - Update any scripts or systemd service configurations that use `--cli`
+
+### Added
+
+- Client discovery system for flexible client selection
+- `--client` flag to specify which client to use (e.g., `--client cli`, `--client gfxhat`, or `--client mypackage:MyClient`)
+- `--list-clients` flag to display available built-in clients
+- Config-based default client selection via `[Client]` section in `pi_pianoteq.conf`
+  - Set default client: `CLIENT = cli` or `CLIENT = mypackage:MyClient`
+- Support for external custom clients using module:class specification
+
+### Changed
+
+- Client selection now uses discoverable system instead of hardcoded imports
+- Logging configuration simplified to use client-provided handlers
+
 ## [2.3.0] - 2025-11-21
 
 ### Added

--- a/docs/development.md
+++ b/docs/development.md
@@ -131,10 +131,77 @@ You can test commands without deploying:
 ```bash
 pipenv run pi-pianoteq --show-config
 pipenv run pi-pianoteq --init-config
-pipenv run pi-pianoteq --cli  # Run CLI client for local testing
+pipenv run pi-pianoteq --client cli  # Run CLI client for local testing
 ```
 
-**Note:** Full testing requires hardware (MIDI, gfxhat) which may not be available on your dev machine. Use `--cli` flag to run the CLI client for testing without the GFX HAT.
+**Note:** Full testing requires hardware (MIDI, gfxhat) which may not be available on your dev machine. Use `--client cli` to run the CLI client for testing without the GFX HAT.
+
+## Using Custom Clients
+
+Pi-Pianoteq supports both built-in clients (gfxhat, cli) and external custom clients.
+
+### Command Line Override
+
+Run with a specific client:
+
+```bash
+pipenv run pi-pianoteq --client cli
+pipenv run pi-pianoteq --client gfxhat
+pipenv run pi-pianoteq --client mypackage.myclient:MyClient
+```
+
+### Set Default Client
+
+Edit your config file to set a default client:
+
+```bash
+pipenv run pi-pianoteq --init-config  # If you haven't already
+nano ~/.config/pi_pianoteq/pi_pianoteq.conf
+```
+
+Add or update the `[Client]` section:
+
+```ini
+[Client]
+CLIENT = cli
+```
+
+Or use an external client:
+
+```ini
+[Client]
+CLIENT = mypackage.myclient:MyClient
+```
+
+### List Available Clients
+
+To see all built-in clients:
+
+```bash
+pipenv run pi-pianoteq --list-clients
+```
+
+### Systemd Service
+
+To use a specific client with the systemd service, edit the service file:
+
+```bash
+sudo systemctl edit pi-pianoteq.service --full
+```
+
+Update the `ExecStart` line to specify the client:
+
+```ini
+[Service]
+ExecStart=/home/pi/pi-pianoteq-venv/bin/pi-pianoteq --client cli
+```
+
+Then reload and restart:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl restart pi-pianoteq.service
+```
 
 ## What deploy.sh Does
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -181,28 +181,6 @@ To see all built-in clients:
 pipenv run pi-pianoteq --list-clients
 ```
 
-### Systemd Service
-
-To use a specific client with the systemd service, edit the service file:
-
-```bash
-sudo systemctl edit pi-pianoteq.service --full
-```
-
-Update the `ExecStart` line to specify the client:
-
-```ini
-[Service]
-ExecStart=/home/pi/pi-pianoteq-venv/bin/pi-pianoteq --client cli
-```
-
-Then reload and restart:
-
-```bash
-sudo systemctl daemon-reload
-sudo systemctl restart pi-pianoteq.service
-```
-
 ## What deploy.sh Does
 
 The deployment script:

--- a/example_client.py
+++ b/example_client.py
@@ -1,0 +1,62 @@
+"""
+Example minimal external client for Pi-Pianoteq.
+
+This demonstrates the minimum required implementation for a custom client.
+You can test it with: pi-pianoteq --client example_client:ExampleClient
+"""
+from typing import Optional
+import logging
+
+from pi_pianoteq.client.client import Client
+from pi_pianoteq.client.client_api import ClientApi
+
+
+class ExampleClient(Client):
+    """
+    Minimal example client that prints to console.
+
+    Demonstrates the basic structure for a custom client.
+    """
+
+    def __init__(self, api: Optional[ClientApi]):
+        """Initialize the client in loading mode (api=None)"""
+        super().__init__(api)
+        print("ExampleClient initialized")
+
+    def set_api(self, api: ClientApi):
+        """Called when the API becomes available"""
+        self.api = api
+        print(f"ExampleClient: API ready with {len(api.get_instruments())} instruments")
+
+    def show_loading_message(self, message: str):
+        """Display loading messages during startup"""
+        print(f"[LOADING] {message}")
+
+    def start(self):
+        """Main client loop - called after set_api()"""
+        print("\nExampleClient started!")
+        print("=" * 60)
+
+        # Show current state
+        instrument = self.api.get_current_instrument()
+        preset = self.api.get_current_preset()
+        print(f"Current: {instrument.name} - {preset.name}")
+
+        # List available instruments
+        print(f"\nAvailable instruments ({len(self.api.get_instruments())}):")
+        for i, instr in enumerate(self.api.get_instruments(), 1):
+            print(f"  {i}. {instr.name}")
+
+        print("\nPress Ctrl+C to exit")
+
+        # Simple loop - just wait for interrupt
+        try:
+            import time
+            while True:
+                time.sleep(1)
+        except KeyboardInterrupt:
+            print("\nExampleClient shutting down...")
+
+    def get_logging_handler(self) -> Optional[logging.Handler]:
+        """Return None to use default stdout/stderr logging"""
+        return None

--- a/src/pi_pianoteq/__main__.py
+++ b/src/pi_pianoteq/__main__.py
@@ -29,6 +29,13 @@ def list_clients():
         info = get_client_info(client_class)
         print(f"  {name:12} - {info.get('description', 'No description')}")
 
+    if not clients:
+        print("  No clients found (all clients have missing dependencies)")
+
+    print()
+    print("Note: Only clients with satisfied dependencies are shown.")
+    print("      Install hardware dependencies to see additional clients.")
+    print("      (e.g., gfxhat requires python3-smbus)")
     print()
     print("Usage:")
     print(f"  pi-pianoteq --client <name>")

--- a/src/pi_pianoteq/__main__.py
+++ b/src/pi_pianoteq/__main__.py
@@ -17,6 +17,27 @@ from pi_pianoteq.logging.logging_config import setup_logging
 logger = logging.getLogger(__name__)
 
 
+def list_clients():
+    """Display available built-in clients"""
+    from pi_pianoteq.client.discovery import discover_builtin_clients, get_client_info
+
+    print("Available built-in clients:")
+    print()
+
+    clients = discover_builtin_clients()
+    for name, client_class in sorted(clients.items()):
+        info = get_client_info(client_class)
+        print(f"  {name:12} - {info.get('description', 'No description')}")
+
+    print()
+    print("Usage:")
+    print(f"  pi-pianoteq --client <name>")
+    print(f"  pi-pianoteq --client mypackage.module:ClassName")
+    print()
+    print("To set a default client, edit the config file:")
+    print(f"  {USER_CONFIG_PATH}")
+
+
 def show_config():
     """Display current configuration and sources"""
     print("Pi-Pianoteq Configuration")
@@ -39,6 +60,7 @@ def show_config():
         ("PIANOTEQ_DIR", Config.PIANOTEQ_DIR),
         ("PIANOTEQ_BIN", Config.PIANOTEQ_BIN),
         ("PIANOTEQ_HEADLESS", Config.PIANOTEQ_HEADLESS),
+        ("CLIENT", Config.CLIENT),
         ("SHUTDOWN_COMMAND", Config.SHUTDOWN_COMMAND),
     ]
 
@@ -77,9 +99,14 @@ def main():
         help='Initialize user config file at ~/.config/pi_pianoteq/ and exit'
     )
     parser.add_argument(
-        '--cli',
+        '--client',
+        type=str,
+        help='Specify client to use (e.g., "cli", "gfxhat", or "mypackage:MyClient")'
+    )
+    parser.add_argument(
+        '--list-clients',
         action='store_true',
-        help='Use CLI client instead of GFX HAT client (for development/testing)'
+        help='List available built-in clients and exit'
     )
     parser.add_argument(
         '--include-demo',
@@ -97,6 +124,10 @@ def main():
     if args.init_config:
         return init_config()
 
+    if args.list_clients:
+        list_clients()
+        return 0
+
     # Normal startup - import hardware dependencies only when needed
     from pi_pianoteq.instrument.library import Library
     from pi_pianoteq.instrument.selector import Selector
@@ -104,21 +135,25 @@ def main():
     from pi_pianoteq.lib.client_lib import ClientLib
     from pi_pianoteq.process.pianoteq import Pianoteq
 
-    # Import appropriate client based on mode
-    if args.cli:
-        from pi_pianoteq.client.cli.cli_client import CliClient
+    # Determine which client to use
+    if args.client:
+        client_spec = args.client
     else:
-        from pi_pianoteq.client.gfxhat.gfxhat_client import GfxhatClient
+        client_spec = Config.CLIENT
 
-    # Instantiate client early (in loading mode, api=None)
-    if args.cli:
-        client = CliClient(api=None)
-    else:
-        client = GfxhatClient(api=None)
+    # Load and instantiate client
+    try:
+        from pi_pianoteq.client.discovery import load_client
+        ClientClass = load_client(client_spec)
+        client = ClientClass(api=None)
+    except (ImportError, AttributeError, ValueError) as e:
+        logger.error(f"Failed to load client '{client_spec}': {e}")
+        print(f"ERROR: Could not load client '{client_spec}'")
+        print("Use --list-clients to see available built-in clients")
+        return 1
 
-    # Setup logging - use buffered handler for CLI mode
-    log_buffer = client.log_buffer if args.cli else None
-    setup_logging(cli_mode=args.cli, log_buffer=log_buffer)
+    # Setup logging with client's handler
+    setup_logging(handler=client.get_logging_handler())
 
     pianoteq = Pianoteq()
 

--- a/src/pi_pianoteq/__main__.py
+++ b/src/pi_pianoteq/__main__.py
@@ -19,23 +19,29 @@ logger = logging.getLogger(__name__)
 
 def list_clients():
     """Display available built-in clients"""
-    from pi_pianoteq.client.discovery import discover_builtin_clients, get_client_info
+    from pi_pianoteq.client.discovery import discover_builtin_clients_with_errors, get_client_info
 
-    print("Available built-in clients:")
+    available, unavailable = discover_builtin_clients_with_errors()
+
+    print("Built-in clients:")
     print()
 
-    clients = discover_builtin_clients()
-    for name, client_class in sorted(clients.items()):
-        info = get_client_info(client_class)
-        print(f"  {name:12} - {info.get('description', 'No description')}")
+    # Show available clients
+    if available:
+        for name, client_class in sorted(available.items()):
+            info = get_client_info(client_class)
+            print(f"  {name:12} - {info.get('description', 'No description')}")
 
-    if not clients:
-        print("  No clients found (all clients have missing dependencies)")
+    # Show unavailable clients with reasons
+    if unavailable:
+        if available:
+            print()
+        for name, error in sorted(unavailable.items()):
+            print(f"  {name:12} - [unavailable: {error}]")
 
-    print()
-    print("Note: Only clients with satisfied dependencies are shown.")
-    print("      Install hardware dependencies to see additional clients.")
-    print("      (e.g., gfxhat requires python3-smbus)")
+    if not available and not unavailable:
+        print("  No clients found")
+
     print()
     print("Usage:")
     print(f"  pi-pianoteq --client <name>")

--- a/src/pi_pianoteq/client/cli/cli_client.py
+++ b/src/pi_pianoteq/client/cli/cli_client.py
@@ -8,6 +8,7 @@ from prompt_toolkit.filters import Condition
 from typing import Optional
 import threading
 import os
+import logging
 
 from pi_pianoteq.client.client import Client
 from pi_pianoteq.client.client_api import ClientApi
@@ -485,3 +486,7 @@ class CliClient(Client):
         # App is already running in background thread, just wait for it
         if self.app_thread:
             self.app_thread.join()
+
+    def get_logging_handler(self) -> Optional[logging.Handler]:
+        """Return BufferedLoggingHandler for UI display"""
+        return self.log_buffer

--- a/src/pi_pianoteq/client/client.py
+++ b/src/pi_pianoteq/client/client.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from typing import Optional
+import logging
 
 from pi_pianoteq.client.client_api import ClientApi
 
@@ -39,5 +40,16 @@ class Client(ABC):
         """
         Start normal client operation.
         Called after set_api().
+        """
+        raise NotImplemented
+
+    @abstractmethod
+    def get_logging_handler(self) -> Optional[logging.Handler]:
+        """
+        Return logging handler to use for this client.
+
+        Returns None to use default stdout/stderr handlers.
+        CLI client returns BufferedLoggingHandler for UI display.
+        GFX HAT client returns None for default behavior.
         """
         raise NotImplemented

--- a/src/pi_pianoteq/client/discovery.py
+++ b/src/pi_pianoteq/client/discovery.py
@@ -1,0 +1,134 @@
+"""
+Client discovery and loading for Pi-Pianoteq.
+
+This module provides functionality to discover and load client implementations,
+both built-in and external.
+"""
+
+import pkgutil
+import importlib
+import inspect
+from typing import Dict, Type, Optional
+from pi_pianoteq.client.client import Client
+
+
+def discover_builtin_clients() -> Dict[str, Type[Client]]:
+    """
+    Scan pi_pianoteq.client.* for Client subclasses.
+
+    Returns:
+        Dictionary mapping client names to client classes (e.g., {'gfxhat': GfxhatClient, 'cli': CliClient})
+    """
+    clients = {}
+
+    # Import the client package to get its path
+    import pi_pianoteq.client as client_package
+
+    # Scan all subpackages and modules in pi_pianoteq.client
+    for importer, modname, ispkg in pkgutil.iter_modules(client_package.__path__):
+        if modname in ['client', 'client_api', 'discovery']:
+            # Skip base classes and this module
+            continue
+
+        try:
+            # Import the module
+            full_module_name = f'pi_pianoteq.client.{modname}'
+            module = importlib.import_module(full_module_name)
+
+            # Look for subpackages (like cli/ and gfxhat/)
+            if ispkg:
+                # Try to import a *_client.py module within the subpackage
+                try:
+                    submodule_name = f'{full_module_name}.{modname}_client'
+                    submodule = importlib.import_module(submodule_name)
+                    module = submodule
+                except ImportError:
+                    # If there's no *_client.py, scan all modules in the subpackage
+                    pass
+
+            # Find Client subclasses in the module
+            for name, obj in inspect.getmembers(module, inspect.isclass):
+                if (issubclass(obj, Client) and
+                    obj is not Client and
+                    obj.__module__.startswith('pi_pianoteq.client')):
+                    # Use the module/package name as the client name
+                    clients[modname] = obj
+                    break  # Only take the first Client subclass from each module
+
+        except ImportError:
+            # Skip modules that can't be imported (e.g., missing dependencies)
+            continue
+
+    return clients
+
+
+def get_client_info(client_class: Type[Client]) -> Dict[str, str]:
+    """
+    Extract metadata from client class.
+
+    Args:
+        client_class: The client class to extract info from
+
+    Returns:
+        Dictionary with 'name' and 'description' keys
+    """
+    # Get description from class docstring
+    doc = client_class.__doc__ or "No description"
+
+    # Take the first line of the docstring as the description
+    description = doc.strip().split('\n')[0].strip()
+
+    return {
+        'name': client_class.__name__,
+        'description': description
+    }
+
+
+def load_client(client_spec: str) -> Type[Client]:
+    """
+    Load client from spec string.
+
+    Args:
+        client_spec: Client specification:
+            - 'gfxhat' or 'cli' -> built-in client
+            - 'mypackage.module:ClassName' -> external client
+
+    Returns:
+        Client class
+
+    Raises:
+        ImportError: If client module cannot be imported
+        AttributeError: If client class cannot be found
+        ValueError: If client spec is invalid
+    """
+    # Check if it's a built-in client first
+    builtin_clients = discover_builtin_clients()
+    if client_spec in builtin_clients:
+        return builtin_clients[client_spec]
+
+    # Try to load as external client (format: 'package.module:ClassName')
+    if ':' not in client_spec:
+        raise ValueError(
+            f"Invalid client spec '{client_spec}'. "
+            f"Use a built-in client name or 'package.module:ClassName' format."
+        )
+
+    module_name, class_name = client_spec.split(':', 1)
+
+    # Import the module
+    try:
+        module = importlib.import_module(module_name)
+    except ImportError as e:
+        raise ImportError(f"Failed to import module '{module_name}': {e}")
+
+    # Get the class from the module
+    try:
+        client_class = getattr(module, class_name)
+    except AttributeError:
+        raise AttributeError(f"Module '{module_name}' has no class '{class_name}'")
+
+    # Verify it's a Client subclass
+    if not (inspect.isclass(client_class) and issubclass(client_class, Client)):
+        raise ValueError(f"{class_name} is not a Client subclass")
+
+    return client_class

--- a/src/pi_pianoteq/client/gfxhat/gfxhat_client.py
+++ b/src/pi_pianoteq/client/gfxhat/gfxhat_client.py
@@ -1,4 +1,5 @@
 import signal
+import logging
 
 from gfxhat import touch, lcd, backlight, fonts
 from PIL import ImageFont
@@ -273,3 +274,7 @@ class GfxhatClient(Client):
             self.menu_display.start_scrolling()
 
         self.update_handler()
+
+    def get_logging_handler(self) -> Optional[logging.Handler]:
+        """Return None to use default stdout/stderr handlers"""
+        return None

--- a/src/pi_pianoteq/config/config.py
+++ b/src/pi_pianoteq/config/config.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 CONFIG_FILE = 'pi_pianoteq.conf'
 PTQ_SECTION = 'Pianoteq'
 MIDI_SECTION = 'Midi'
+CLIENT_SECTION = 'Client'
 SYSTEM_SECTION = 'System'
 
 # Config file locations (in priority order: user config > bundled default)
@@ -175,6 +176,8 @@ class ConfigLoader:
 
         headless_str = self._get_config('PIANOTEQ_HEADLESS', PTQ_SECTION, user_parser, default_parser, user_config_loaded)
         self.PIANOTEQ_HEADLESS = headless_str.lower() == "true"
+
+        self.CLIENT = self._get_config('CLIENT', CLIENT_SECTION, user_parser, default_parser, user_config_loaded)
 
         self.SHUTDOWN_COMMAND = self._get_config('SHUTDOWN_COMMAND', SYSTEM_SECTION, user_parser, default_parser, user_config_loaded)
 

--- a/src/pi_pianoteq/config/pi_pianoteq.conf
+++ b/src/pi_pianoteq/config/pi_pianoteq.conf
@@ -3,5 +3,11 @@ PIANOTEQ_DIR = ~/pianoteq/Pianoteq 8 STAGE/arm-64bit/
 PIANOTEQ_BIN = Pianoteq 8 STAGE
 PIANOTEQ_HEADLESS = true
 
+[Client]
+# Built-in clients: 'gfxhat', 'cli'
+# External clients: 'package.module:ClassName'
+# Default: gfxhat
+CLIENT = gfxhat
+
 [System]
 SHUTDOWN_COMMAND = sudo shutdown -h now

--- a/tests/client/test_discovery.py
+++ b/tests/client/test_discovery.py
@@ -2,6 +2,7 @@
 import pytest
 from pi_pianoteq.client.discovery import (
     discover_builtin_clients,
+    discover_builtin_clients_with_errors,
     get_client_info,
     load_client
 )
@@ -101,3 +102,37 @@ class TestLoadClient:
         # Missing colon
         with pytest.raises(ValueError):
             load_client('some_invalid_spec_without_colon')
+
+
+class TestDiscoverBuiltinClientsWithErrors:
+    """Test client discovery with error tracking"""
+
+    def test_discovers_both_available_and_unavailable(self):
+        """Test that both available and unavailable clients are discovered"""
+        available, unavailable = discover_builtin_clients_with_errors()
+
+        # In test environment (with mocked gfxhat), both should be available
+        assert 'cli' in available
+        assert 'gfxhat' in available
+
+    def test_returns_tuple_of_dicts(self):
+        """Test that function returns tuple of two dicts"""
+        result = discover_builtin_clients_with_errors()
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+        available, unavailable = result
+        assert isinstance(available, dict)
+        assert isinstance(unavailable, dict)
+
+    def test_available_clients_are_client_subclasses(self):
+        """Test that all available clients are Client subclasses"""
+        available, _ = discover_builtin_clients_with_errors()
+        for name, client_class in available.items():
+            assert issubclass(client_class, Client)
+
+    def test_unavailable_clients_have_error_messages(self):
+        """Test that unavailable clients have error message strings"""
+        _, unavailable = discover_builtin_clients_with_errors()
+        for name, error_msg in unavailable.items():
+            assert isinstance(error_msg, str)
+            assert len(error_msg) > 0

--- a/tests/client/test_discovery.py
+++ b/tests/client/test_discovery.py
@@ -1,0 +1,103 @@
+"""Tests for client discovery module"""
+import pytest
+from pi_pianoteq.client.discovery import (
+    discover_builtin_clients,
+    get_client_info,
+    load_client
+)
+from pi_pianoteq.client.client import Client
+from pi_pianoteq.client.cli.cli_client import CliClient
+from pi_pianoteq.client.gfxhat.gfxhat_client import GfxhatClient
+
+
+class TestDiscoverBuiltinClients:
+    """Test built-in client discovery"""
+
+    def test_discover_finds_gfxhat_and_cli(self):
+        """Test that gfxhat and cli clients are discovered"""
+        clients = discover_builtin_clients()
+        assert 'gfxhat' in clients
+        assert 'cli' in clients
+
+    def test_discovered_clients_are_client_subclasses(self):
+        """Test that all discovered clients are Client subclasses"""
+        clients = discover_builtin_clients()
+        for name, client_class in clients.items():
+            assert issubclass(client_class, Client)
+
+    def test_gfxhat_client_class(self):
+        """Test that gfxhat client is GfxhatClient"""
+        clients = discover_builtin_clients()
+        assert clients['gfxhat'] == GfxhatClient
+
+    def test_cli_client_class(self):
+        """Test that cli client is CliClient"""
+        clients = discover_builtin_clients()
+        assert clients['cli'] == CliClient
+
+
+class TestGetClientInfo:
+    """Test client info extraction"""
+
+    def test_get_cli_client_info(self):
+        """Test extracting info from CLI client"""
+        info = get_client_info(CliClient)
+        assert 'name' in info
+        assert 'description' in info
+        assert info['name'] == 'CliClient'
+        assert len(info['description']) > 0
+
+    def test_get_gfxhat_client_info(self):
+        """Test extracting info from GFX HAT client"""
+        info = get_client_info(GfxhatClient)
+        assert 'name' in info
+        assert 'description' in info
+        assert info['name'] == 'GfxhatClient'
+        assert len(info['description']) > 0
+
+
+class TestLoadClient:
+    """Test client loading"""
+
+    def test_load_builtin_cli_client(self):
+        """Test loading built-in CLI client by name"""
+        client_class = load_client('cli')
+        assert client_class == CliClient
+
+    def test_load_builtin_gfxhat_client(self):
+        """Test loading built-in GFX HAT client by name"""
+        client_class = load_client('gfxhat')
+        assert client_class == GfxhatClient
+
+    def test_load_external_client_by_module_spec(self):
+        """Test loading external client by module:class spec"""
+        # Use CliClient as an example external client
+        client_class = load_client('pi_pianoteq.client.cli.cli_client:CliClient')
+        assert client_class == CliClient
+
+    def test_load_invalid_client_raises_value_error(self):
+        """Test that loading invalid client raises ValueError"""
+        with pytest.raises(ValueError):
+            load_client('nonexistent')
+
+    def test_load_client_with_invalid_module_raises_import_error(self):
+        """Test that loading client with invalid module raises ImportError"""
+        with pytest.raises(ImportError):
+            load_client('nonexistent.module:NonexistentClient')
+
+    def test_load_client_with_invalid_class_raises_attribute_error(self):
+        """Test that loading client with invalid class raises AttributeError"""
+        with pytest.raises(AttributeError):
+            load_client('pi_pianoteq.client.cli.cli_client:NonexistentClass')
+
+    def test_load_client_with_non_client_class_raises_value_error(self):
+        """Test that loading a non-Client class raises ValueError"""
+        # Try to load a class that's not a Client subclass
+        with pytest.raises(ValueError):
+            load_client('pi_pianoteq.client.discovery:get_client_info')
+
+    def test_load_client_with_invalid_spec_format_raises_value_error(self):
+        """Test that loading client with invalid spec format raises ValueError"""
+        # Missing colon
+        with pytest.raises(ValueError):
+            load_client('some_invalid_spec_without_colon')


### PR DESCRIPTION
Replace hardcoded --cli flag with flexible client discovery system.

Breaking Changes:
- Remove --cli flag (use --client cli instead)

Features:
- Add client discovery module for automatic client detection
- Add --client flag to specify client (e.g., --client cli, --client gfxhat)
- Add --list-clients flag to display available built-in clients
- Add config-based default client selection via [Client] section
- Support external custom clients via module:class specification
- Simplify logging configuration to use client-provided handlers

Implementation:
- Create src/pi_pianoteq/client/discovery.py with client discovery logic
- Add get_logging_handler() abstract method to Client base class
- Implement get_logging_handler() in CliClient and GfxhatClient
- Update logging_config.py to accept optional handler parameter
- Add CLIENT config option to pi_pianoteq.conf and Config class
- Update __main__.py to use config-based client selection
- Add comprehensive tests for client discovery and config

Documentation:
- Update docs/development.md with custom client usage examples
- Update CHANGELOG.md with breaking change notice