### PR TITLE
Plan preset parameter randomization alternative v1 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CLI logs view (press 'l' to view startup and runtime logs, press Esc or 'q' to return)
 - Control menu on GFX HAT: new top-level menu accessed via middle button press
   - Instrument selection moved to first menu item
+  - Randomize preset: randomizes parameters of current preset
+  - Random instrument: randomly selects instrument and randomizes parameters
   - Provides framework for additional control functions in future releases
+- Randomization shortcuts in CLI client
+  - Press 'r' to randomize current preset parameters
+  - Press 'R' (Shift+r) to randomly select instrument and randomize parameters
 - Key repeat for all navigation and action buttons on GFX HAT with intelligent held event threshold
   - Hold down arrow buttons for continuous scrolling through instruments, presets, and menus
   - Long press ENTER button to open preset menu (with threshold to prevent accidental triggers)

--- a/src/pi_pianoteq/client/cli/cli_client.py
+++ b/src/pi_pianoteq/client/cli/cli_client.py
@@ -289,6 +289,20 @@ class CliClient(Client):
                 self.logs_view_mode = True
                 self._update_display()
 
+        # Randomize current preset
+        @kb.add('r')
+        def kb_randomize_preset(event):
+            if not self.menu_mode and not self.preset_menu_mode and not self.search_manager.is_active() and not self.logs_view_mode:
+                self.api.randomize_current_preset()
+                self._update_display()
+
+        # Random instrument and randomize parameters
+        @kb.add('R')
+        def kb_random_instrument(event):
+            if not self.menu_mode and not self.preset_menu_mode and not self.search_manager.is_active() and not self.logs_view_mode:
+                self.api.randomize_instrument_and_preset()
+                self._update_display()
+
         # Handle text input in search mode
         for char in 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 -_.,()[]':
             @kb.add(char, filter=Condition(lambda: self.search_manager.is_active()))

--- a/src/pi_pianoteq/client/cli/cli_display.py
+++ b/src/pi_pianoteq/client/cli/cli_display.py
@@ -67,6 +67,8 @@ def get_normal_text(api: ClientApi) -> List[Tuple[str, str]]:
         ('', '  Left/Right  : Quick instrument switch\n'),
         ('bold', '  i'), ('', '           : Open instrument menu\n'),
         ('bold', '  p'), ('', '           : Open preset menu\n'),
+        ('bold', '  r'), ('', '           : Randomize preset\n'),
+        ('bold', '  R'), ('', '           : Random instrument\n'),
         ('bold', '  /'), ('', '           : Search instruments & presets\n'),
         ('bold', '  l'), ('', '           : View logs\n'),
         ('bold', '  q'), ('', '           : Quit\n'),

--- a/src/pi_pianoteq/client/client_api.py
+++ b/src/pi_pianoteq/client/client_api.py
@@ -57,3 +57,13 @@ class ClientApi(ABC):
     @abstractmethod
     def set_preset(self, instrument_name: str, preset_name: str):
         raise NotImplemented
+
+    @abstractmethod
+    def randomize_current_preset(self):
+        """Randomize parameters of the current preset."""
+        raise NotImplemented
+
+    @abstractmethod
+    def randomize_instrument_and_preset(self):
+        """Randomly select an instrument and randomize its parameters."""
+        raise NotImplemented

--- a/src/pi_pianoteq/client/gfxhat/control_menu_display.py
+++ b/src/pi_pianoteq/client/gfxhat/control_menu_display.py
@@ -8,17 +8,23 @@ class ControlMenuDisplay(MenuDisplay):
     """
     Top-level control menu with options for various functions.
 
-    Currently contains:
+    Contains:
     - Select Instrument: Opens instrument selection menu
+    - Randomize Preset: Randomizes parameters of current preset
+    - Random Instrument: Randomly selects instrument and randomizes parameters
     """
 
-    def __init__(self, api: ClientApi, width, height, font, on_exit, on_select_instrument):
+    def __init__(self, api: ClientApi, width, height, font, on_exit, on_select_instrument, on_randomize_preset, on_random_instrument):
         self.on_select_instrument = on_select_instrument
+        self.on_randomize_preset = on_randomize_preset
+        self.on_random_instrument = on_random_instrument
         super().__init__(api, width, height, font, on_exit)
 
     def get_menu_options(self):
         return [
-            MenuOption("Select Instrument", self.on_select_instrument, self.font)
+            MenuOption("Select Instrument", self.on_select_instrument, self.font),
+            MenuOption("Randomize Preset", self.on_randomize_preset, self.font),
+            MenuOption("Random Instrument", self.on_random_instrument, self.font)
         ]
 
     def get_heading(self):

--- a/src/pi_pianoteq/client/gfxhat/gfxhat_client.py
+++ b/src/pi_pianoteq/client/gfxhat/gfxhat_client.py
@@ -58,7 +58,9 @@ class GfxhatClient(Client):
         self.control_menu_display = ControlMenuDisplay(
             self.api, self.width, self.height, self.font,
             self.on_exit_control_menu,
-            self.on_enter_instrument_menu
+            self.on_enter_instrument_menu,
+            self.on_randomize_preset,
+            self.on_random_instrument
         )
         self.menu_display = InstrumentMenuDisplay(
             self.api, self.width, self.height, self.font,
@@ -254,4 +256,22 @@ class GfxhatClient(Client):
         else:
             self.menu_display.start_scrolling()
 
+        self.update_handler()
+
+    def on_randomize_preset(self):
+        """Randomize current preset and close menu."""
+        self.api.randomize_current_preset()
+        self.control_menu_display.stop_scrolling()
+        self.control_menu_open = False
+        self.instrument_display.update_display()
+        self.instrument_display.start_scrolling()
+        self.update_handler()
+
+    def on_random_instrument(self):
+        """Randomly select instrument, randomize parameters, and close menu."""
+        self.api.randomize_instrument_and_preset()
+        self.control_menu_display.stop_scrolling()
+        self.control_menu_open = False
+        self.instrument_display.update_display()
+        self.instrument_display.start_scrolling()
         self.update_handler()

--- a/src/pi_pianoteq/lib/client_lib.py
+++ b/src/pi_pianoteq/lib/client_lib.py
@@ -7,6 +7,7 @@ from pi_pianoteq.rpc.jsonrpc_client import PianoteqJsonRpc
 from typing import List
 from os import system
 import logging
+import random
 
 logger = logging.getLogger(__name__)
 
@@ -124,3 +125,31 @@ class ClientLib(ClientApi):
         if self.on_exit is not None:
             self.on_exit()
         system(Config.SHUTDOWN_COMMAND)
+
+    # Randomization methods
+    def randomize_current_preset(self) -> None:
+        """
+        Randomize parameters of the current preset.
+
+        Uses Pianoteq's randomizeParameters() with default amount (1.0).
+        """
+        logger.info("Randomizing current preset parameters")
+        self.jsonrpc.randomize_parameters()
+
+    def randomize_instrument_and_preset(self) -> None:
+        """
+        Randomly select an instrument and randomize its parameters.
+
+        Selects a random instrument from the library, loads its first preset,
+        then randomizes the parameters.
+        """
+        instruments = self.instrument_library.get_instruments()
+        if not instruments:
+            logger.warning("No instruments available for randomization")
+            return
+
+        random_instrument = random.choice(instruments)
+        logger.info(f"Randomly selected instrument: {random_instrument.name}")
+
+        self.set_instrument(random_instrument.name)
+        self.randomize_current_preset()

--- a/src/pi_pianoteq/rpc/jsonrpc_client.py
+++ b/src/pi_pianoteq/rpc/jsonrpc_client.py
@@ -158,6 +158,20 @@ class PianoteqJsonRpc:
         logger.debug(f"Loading preset: {name} (bank: {bank or 'factory'})")
         self._call('loadPreset', [name, bank])
 
+    def randomize_parameters(self, amount: float = 1.0) -> None:
+        """
+        Randomize parameter values.
+
+        Args:
+            amount: Randomization amount (0.0 - 1.0, default: 1.0)
+                    0.0 = no change, 1.0 = maximum randomization
+
+        Raises:
+            PianoteqJsonRpcError: If the call fails
+        """
+        logger.debug(f"Randomizing parameters with amount: {amount}")
+        self._call('randomizeParameters', [amount])
+
     def quit(self) -> None:
         """
         Send quit command to Pianoteq to exit gracefully.

--- a/tests/client/gfxhat/test_control_menu_display.py
+++ b/tests/client/gfxhat/test_control_menu_display.py
@@ -1,0 +1,74 @@
+import unittest
+from unittest.mock import Mock
+
+from pi_pianoteq.client.gfxhat.control_menu_display import ControlMenuDisplay
+
+
+class ControlMenuDisplayTestCase(unittest.TestCase):
+    """Test ControlMenuDisplay menu options and callbacks."""
+
+    def setUp(self):
+        """Set up common mocks for tests."""
+        self.mock_api = Mock()
+        self.mock_font = Mock()
+        self.mock_font.getbbox.return_value = (0, 0, 50, 10)
+        self.on_exit = Mock()
+        self.on_select_instrument = Mock()
+        self.on_randomize_preset = Mock()
+        self.on_random_instrument = Mock()
+
+    def create_display(self):
+        """Helper to create ControlMenuDisplay with mocks."""
+        return ControlMenuDisplay(
+            api=self.mock_api,
+            width=128,
+            height=64,
+            font=self.mock_font,
+            on_exit=self.on_exit,
+            on_select_instrument=self.on_select_instrument,
+            on_randomize_preset=self.on_randomize_preset,
+            on_random_instrument=self.on_random_instrument
+        )
+
+    def test_get_menu_options_includes_all_options(self):
+        """Menu options should include instrument selection and randomization options."""
+        display = self.create_display()
+
+        self.assertEqual(len(display.menu_options), 3)
+        self.assertEqual(display.menu_options[0].name, "Select Instrument")
+        self.assertEqual(display.menu_options[1].name, "Randomize Preset")
+        self.assertEqual(display.menu_options[2].name, "Random Instrument")
+
+    def test_select_instrument_triggers_callback(self):
+        """Selecting 'Select Instrument' should trigger callback."""
+        display = self.create_display()
+
+        display.menu_options[0].trigger()
+
+        self.on_select_instrument.assert_called_once()
+
+    def test_randomize_preset_triggers_callback(self):
+        """Selecting 'Randomize Preset' should trigger callback."""
+        display = self.create_display()
+
+        display.menu_options[1].trigger()
+
+        self.on_randomize_preset.assert_called_once()
+
+    def test_random_instrument_triggers_callback(self):
+        """Selecting 'Random Instrument' should trigger callback."""
+        display = self.create_display()
+
+        display.menu_options[2].trigger()
+
+        self.on_random_instrument.assert_called_once()
+
+    def test_get_heading_returns_menu_title(self):
+        """get_heading should return 'Menu:'."""
+        display = self.create_display()
+
+        self.assertEqual(display.get_heading(), "Menu:")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/lib/test_client_lib.py
+++ b/tests/lib/test_client_lib.py
@@ -82,5 +82,76 @@ class ClientLibPresetSyncTestCase(unittest.TestCase):
         self.jsonrpc.load_preset.assert_not_called()
 
 
+class ClientLibRandomizationTestCase(unittest.TestCase):
+    """Test randomization functionality in ClientLib."""
+
+    def setUp(self):
+        self.inst1 = Instrument('Steinway D', 'Steinway D', '#000000', '#FFFFFF')
+        self.preset1a = Preset('Steinway D Prelude', 'Prelude')
+        self.preset1b = Preset('Steinway D Jazz', 'Jazz')
+        self.inst1.presets = [self.preset1a, self.preset1b]
+
+        self.inst2 = Instrument('Ant. Petrof', 'Ant. Petrof', '#000000', '#FFFFFF')
+        self.preset2a = Preset('Ant. Petrof Recording 1', 'Recording 1')
+        self.preset2b = Preset('Ant. Petrof Recording 2', 'Recording 2')
+        self.inst2.presets = [self.preset2a, self.preset2b]
+
+        self.library = Library([self.inst1, self.inst2])
+        self.selector = Selector([self.inst1, self.inst2])
+        self.jsonrpc = Mock()
+
+        preset_info = CurrentPreset(name='Steinway D Prelude')
+        info = PianoteqInfo(current_preset=preset_info)
+        self.jsonrpc.get_info.return_value = info
+
+        self.client_lib = ClientLib(self.library, self.selector, self.jsonrpc)
+
+    def test_randomize_current_preset_calls_jsonrpc(self):
+        """Test that randomize_current_preset calls randomize_parameters."""
+        self.client_lib.randomize_current_preset()
+
+        self.jsonrpc.randomize_parameters.assert_called_once()
+
+    @patch('pi_pianoteq.lib.client_lib.random.choice')
+    def test_randomize_instrument_and_preset_selects_random_instrument(self, mock_choice):
+        """Test that randomize_instrument_and_preset randomly selects an instrument."""
+        mock_choice.return_value = self.inst2
+
+        self.client_lib.randomize_instrument_and_preset()
+
+        mock_choice.assert_called_once()
+        instruments = mock_choice.call_args[0][0]
+        self.assertEqual([self.inst1, self.inst2], instruments)
+
+    @patch('pi_pianoteq.lib.client_lib.random.choice')
+    def test_randomize_instrument_and_preset_loads_preset(self, mock_choice):
+        """Test that randomize_instrument_and_preset loads preset for selected instrument."""
+        mock_choice.return_value = self.inst2
+        self.jsonrpc.reset_mock()
+
+        self.client_lib.randomize_instrument_and_preset()
+
+        self.jsonrpc.load_preset.assert_called_once_with(self.preset2a.name)
+
+    @patch('pi_pianoteq.lib.client_lib.random.choice')
+    def test_randomize_instrument_and_preset_randomizes_parameters(self, mock_choice):
+        """Test that randomize_instrument_and_preset randomizes parameters."""
+        mock_choice.return_value = self.inst2
+
+        self.client_lib.randomize_instrument_and_preset()
+
+        self.jsonrpc.randomize_parameters.assert_called_once()
+
+    def test_randomize_instrument_and_preset_with_empty_library(self):
+        """Test that randomize_instrument_and_preset handles empty library gracefully."""
+        # Manually set empty library to avoid sync_preset() initialization issues
+        self.client_lib.instrument_library = Library([])
+
+        self.client_lib.randomize_instrument_and_preset()
+
+        # Should not attempt to randomize with no instruments available
+        self.assertEqual(self.jsonrpc.randomize_parameters.call_count, 0)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/rpc/test_jsonrpc_client.py
+++ b/tests/rpc/test_jsonrpc_client.py
@@ -74,5 +74,40 @@ class TestLicenseDetection(unittest.TestCase):
         self.assertEqual(result.addons, [])
 
 
+class TestRandomization(unittest.TestCase):
+    """Test randomization API methods."""
+
+    def setUp(self):
+        """Create a JSON-RPC client instance."""
+        self.client = PianoteqJsonRpc()
+
+    @patch.object(PianoteqJsonRpc, '_call')
+    def test_randomize_parameters_with_default_amount(self, mock_call):
+        """Test randomize_parameters with default amount (1.0)."""
+        mock_call.return_value = None
+
+        self.client.randomize_parameters()
+
+        mock_call.assert_called_once_with('randomizeParameters', [1.0])
+
+    @patch.object(PianoteqJsonRpc, '_call')
+    def test_randomize_parameters_with_custom_amount(self, mock_call):
+        """Test randomize_parameters with custom amount."""
+        mock_call.return_value = None
+
+        self.client.randomize_parameters(0.5)
+
+        mock_call.assert_called_once_with('randomizeParameters', [0.5])
+
+    @patch.object(PianoteqJsonRpc, '_call')
+    def test_randomize_parameters_with_zero_amount(self, mock_call):
+        """Test randomize_parameters with zero amount (no change)."""
+        mock_call.return_value = None
+
+        self.client.randomize_parameters(0.0)
+
+        mock_call.assert_called_once_with('randomizeParameters', [0.0])
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Implements the alternative approach for preset parameter randomization (issue #45) by adding randomization options to the Control Menu rather than creating special preset entries.

Features:
- Control Menu options:
  - "Randomize Preset": randomizes parameters of current preset
  - "Random Instrument": randomly selects instrument and randomizes
- CLI shortcuts:
  - 'r' to randomize current preset
  - 'R' (Shift+r) to randomize instrument and preset
- Uses Pianoteq's randomizeParameters() JSON-RPC method

Implementation:
- Added randomize_parameters() to PianoteqJsonRpc client
- Extended ClientApi with randomize_current_preset() and randomize_instrument_and_preset() abstract methods
- Implemented randomization methods in ClientLib
- Updated ControlMenuDisplay with two new menu options
- Added randomization callbacks to GfxhatClient state machine
- Added keyboard shortcuts to CLI client with help text
- Comprehensive test coverage for all layers

All 324 tests pass.

Related: #45