### PR TITLE
Sync Pianoteq state using API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ pi-pianoteq = "pi_pianoteq.__main__:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"}
-packages = ["pi_pianoteq", "pi_pianoteq.client", "pi_pianoteq.client.cli", "pi_pianoteq.client.gfxhat", "pi_pianoteq.config", "pi_pianoteq.instrument", "pi_pianoteq.lib", "pi_pianoteq.logging", "pi_pianoteq.midi", "pi_pianoteq.process", "pi_pianoteq.rpc", "pi_pianoteq.util"]
+packages = ["pi_pianoteq", "pi_pianoteq.client", "pi_pianoteq.client.cli", "pi_pianoteq.client.gfxhat", "pi_pianoteq.config", "pi_pianoteq.instrument", "pi_pianoteq.lib", "pi_pianoteq.logging", "pi_pianoteq.midi", "pi_pianoteq.process", "pi_pianoteq.rpc", "pi_pianoteq.state", "pi_pianoteq.util"]
 
 [tool.setuptools.package-data]
 "pi_pianoteq.config" = ["pi_pianoteq.conf"]

--- a/src/pi_pianoteq/__main__.py
+++ b/src/pi_pianoteq/__main__.py
@@ -210,6 +210,9 @@ def main():
     # Provide API and start normal operation
     client.set_api(client_lib)
     client.start()
+
+    # Cleanup state monitor before shutting down
+    client_lib.cleanup()
     pianoteq.quit()
 
     return 0

--- a/src/pi_pianoteq/client/cli/cli_client.py
+++ b/src/pi_pianoteq/client/cli/cli_client.py
@@ -124,8 +124,15 @@ class CliClient(Client):
         self.application.layout = self.normal_layout
         self.application.key_bindings = self.normal_kb
 
+        # Subscribe to state changes
+        self.api.subscribe_to_state_changes(self._on_state_change)
+
         # Trigger redraw
         self.application.invalidate()
+
+    def _on_state_change(self, state):
+        """Update display when Pianoteq state changes externally."""
+        self._update_display()
 
     def _build_normal_layout(self):
         """Build the normal interactive layout (requires API)"""

--- a/src/pi_pianoteq/client/cli/cli_display.py
+++ b/src/pi_pianoteq/client/cli/cli_display.py
@@ -52,7 +52,7 @@ def get_title(search_manager: SearchManager, preset_menu_mode: bool,
 def get_normal_text(api: ClientApi) -> List[Tuple[str, str]]:
     """Generate normal mode display using formatted text tuples"""
     instrument = api.get_current_instrument()
-    preset = api.get_current_preset().display_name
+    preset = api.get_current_preset().get_display_name_with_modified()
 
     lines = [
         ('', '\n'),
@@ -161,7 +161,8 @@ def get_preset_menu_text(api: ClientApi, preset_menu_instrument: str,
     for i in range(start_idx, end_idx):
         preset = presets[i]
         # Truncate long names to fit in display
-        display_name = preset.display_name[:58] if len(preset.display_name) > 58 else preset.display_name
+        display_name_full = preset.get_display_name_with_modified()
+        display_name = display_name_full[:58] if len(display_name_full) > 58 else display_name_full
 
         if i == current_menu_index:
             # Highlight selected item

--- a/src/pi_pianoteq/client/cli/search_manager.py
+++ b/src/pi_pianoteq/client/cli/search_manager.py
@@ -64,7 +64,7 @@ class SearchManager:
                 return
 
             presets = self.api.get_presets(self.preset_menu_instrument)
-            all_items = [(p.display_name, 'preset', p.name) for p in presets]
+            all_items = [(p.get_display_name_with_modified(), 'preset', p.name) for p in presets]
 
         else:  # combined
             # Search both instruments and presets
@@ -77,7 +77,7 @@ class SearchManager:
             # Add presets from all instruments
             for instrument in self.api.get_instruments():
                 for preset in instrument.presets:
-                    display = f"{preset.display_name} ({instrument.name})"
+                    display = f"{preset.get_display_name_with_modified()} ({instrument.name})"
                     all_items.append((display, 'preset', (instrument.name, preset.name)))
 
         # Filter items by query

--- a/src/pi_pianoteq/client/gfxhat/instrument_display.py
+++ b/src/pi_pianoteq/client/gfxhat/instrument_display.py
@@ -30,7 +30,7 @@ class InstrumentDisplay:
         self.held_count = {}
         self.held_threshold = 2
         current_instrument = self.api.get_current_instrument()
-        self.preset = self.api.get_current_preset().display_name
+        self.preset = self.api.get_current_preset().get_display_name_with_modified()
         self.instrument = current_instrument.name
         self.background_primary = current_instrument.background_primary
         self.background_secondary = current_instrument.background_secondary
@@ -42,6 +42,13 @@ class InstrumentDisplay:
         self.draw_text()
         self.backlight = Backlight("000000")
         self.set_backlight()
+
+        # Subscribe to state changes
+        self.api.subscribe_to_state_changes(self._on_state_change)
+
+    def _on_state_change(self, state):
+        """Update display when Pianoteq state changes externally."""
+        self.update_display()
 
     def draw_text(self):
         """
@@ -148,9 +155,9 @@ class InstrumentDisplay:
         return self.image
 
     def update_display(self):
-        """Update display when instrument/preset changes (e.g., button press)."""
+        """Update display when instrument/preset changes (e.g., button press or external state change)."""
         current_instrument = self.api.get_current_instrument()
-        self.preset = self.api.get_current_preset().display_name
+        self.preset = self.api.get_current_preset().get_display_name_with_modified()
         self.instrument = current_instrument.name
         self.background_primary = current_instrument.background_primary
         self.background_secondary = current_instrument.background_secondary

--- a/src/pi_pianoteq/client/gfxhat/preset_menu_display.py
+++ b/src/pi_pianoteq/client/gfxhat/preset_menu_display.py
@@ -36,7 +36,7 @@ class PresetMenuDisplay(MenuDisplay):
         # Add all presets for this instrument
         presets = self.api.get_presets(self.instrument_name)
         for preset in presets:
-            options.append(MenuOption(preset.display_name, self.set_preset, self.font, (preset.name,)))
+            options.append(MenuOption(preset.get_display_name_with_modified(), self.set_preset, self.font, (preset.name,)))
 
         return options
 

--- a/src/pi_pianoteq/instrument/preset.py
+++ b/src/pi_pianoteq/instrument/preset.py
@@ -2,13 +2,26 @@ from typing import Optional
 
 
 class Preset:
-    def __init__(self, name: str, display_name: Optional[str] = None):
+    def __init__(self, name: str, display_name: Optional[str] = None, modified: bool = False):
         """
         Create a Preset instance.
 
         Args:
             name: The full preset name from Pianoteq API
             display_name: The formatted name for display (computed during library construction)
+            modified: Whether the preset has been modified from its saved state
         """
         self.name = name
         self.display_name = display_name or name
+        self.modified = modified
+
+    def get_display_name_with_modified(self) -> str:
+        """
+        Get display name with (modified) suffix if preset has been modified.
+
+        Returns:
+            Display name, with " (modified)" appended if modified=True
+        """
+        if self.modified:
+            return f"{self.display_name} (modified)"
+        return self.display_name

--- a/src/pi_pianoteq/state/__init__.py
+++ b/src/pi_pianoteq/state/__init__.py
@@ -1,0 +1,1 @@
+"""State management and synchronization for Pianoteq."""

--- a/src/pi_pianoteq/state/state_monitor.py
+++ b/src/pi_pianoteq/state/state_monitor.py
@@ -1,0 +1,163 @@
+"""
+State monitor for tracking Pianoteq state changes.
+
+Polls Pianoteq's getInfo() API periodically to detect when the preset or
+modification state changes outside of the program. Notifies subscribers
+via callbacks only when actual changes are detected.
+"""
+
+import logging
+import threading
+import time
+from dataclasses import dataclass
+from typing import Callable, List, Optional
+
+from pi_pianoteq.rpc.jsonrpc_client import PianoteqJsonRpc, PianoteqJsonRpcError
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PianoteqState:
+    """Current state of Pianoteq."""
+    preset_name: str
+    modified: bool
+
+
+class StateMonitor:
+    """
+    Monitors Pianoteq state and notifies subscribers of changes.
+
+    Runs a background thread that polls getInfo() periodically.
+    Only calls callbacks when state actually changes to minimize overhead.
+    """
+
+    def __init__(self, jsonrpc: PianoteqJsonRpc, poll_interval: float = 1.0):
+        """
+        Initialize state monitor.
+
+        Args:
+            jsonrpc: Pianoteq JSON-RPC client
+            poll_interval: How often to poll for state changes (seconds)
+        """
+        self.jsonrpc = jsonrpc
+        self.poll_interval = poll_interval
+
+        self._callbacks: List[Callable[[PianoteqState], None]] = []
+        self._callbacks_lock = threading.Lock()
+
+        self._current_state: Optional[PianoteqState] = None
+        self._state_lock = threading.Lock()
+
+        self._thread: Optional[threading.Thread] = None
+        self._stop_event = threading.Event()
+        self._running = False
+
+    def subscribe(self, callback: Callable[[PianoteqState], None]) -> None:
+        """
+        Subscribe to state changes.
+
+        The callback will be called only when the state changes (preset name
+        or modified flag). It will not be called on every poll, only when
+        actual changes are detected.
+
+        Args:
+            callback: Function to call when state changes.
+                     Receives PianoteqState as argument.
+        """
+        with self._callbacks_lock:
+            self._callbacks.append(callback)
+            logger.debug(f"State change callback registered (total: {len(self._callbacks)})")
+
+    def unsubscribe(self, callback: Callable[[PianoteqState], None]) -> None:
+        """Unsubscribe from state changes."""
+        with self._callbacks_lock:
+            if callback in self._callbacks:
+                self._callbacks.remove(callback)
+                logger.debug(f"State change callback unregistered (total: {len(self._callbacks)})")
+
+    def get_current_state(self) -> Optional[PianoteqState]:
+        """Get the last known state (thread-safe)."""
+        with self._state_lock:
+            return self._current_state
+
+    def start(self) -> None:
+        """Start the state monitoring thread."""
+        if self._running:
+            logger.warning("StateMonitor already running")
+            return
+
+        self._stop_event.clear()
+        self._running = True
+        self._thread = threading.Thread(target=self._monitor_loop, daemon=True, name="StateMonitor")
+        self._thread.start()
+        logger.info(f"State monitor started (poll interval: {self.poll_interval}s)")
+
+    def stop(self) -> None:
+        """Stop the state monitoring thread."""
+        if not self._running:
+            return
+
+        logger.info("Stopping state monitor...")
+        self._stop_event.set()
+        if self._thread:
+            self._thread.join(timeout=5.0)
+        self._running = False
+        logger.info("State monitor stopped")
+
+    def _monitor_loop(self) -> None:
+        """Main monitoring loop (runs in background thread)."""
+        while not self._stop_event.is_set():
+            try:
+                self._check_state()
+            except Exception as e:
+                logger.warning(f"Error checking Pianoteq state: {e}")
+
+            # Sleep in small increments to allow quick shutdown
+            for _ in range(int(self.poll_interval * 10)):
+                if self._stop_event.is_set():
+                    break
+                time.sleep(0.1)
+
+    def _check_state(self) -> None:
+        """Check current Pianoteq state and notify if changed."""
+        try:
+            info = self.jsonrpc.get_info()
+            new_state = PianoteqState(
+                preset_name=info.current_preset.name,
+                modified=info.modified
+            )
+
+            # Check if state changed
+            state_changed = False
+            with self._state_lock:
+                if self._current_state is None:
+                    # First check - initialize state but don't notify
+                    self._current_state = new_state
+                    logger.debug(f"Initial state: {new_state.preset_name} (modified={new_state.modified})")
+                elif (self._current_state.preset_name != new_state.preset_name or
+                      self._current_state.modified != new_state.modified):
+                    # State changed - update and notify
+                    logger.info(f"State change detected: {self._current_state.preset_name} "
+                               f"(modified={self._current_state.modified}) -> "
+                               f"{new_state.preset_name} (modified={new_state.modified})")
+                    self._current_state = new_state
+                    state_changed = True
+
+            # Notify subscribers (outside lock to avoid deadlock)
+            if state_changed:
+                self._notify_subscribers(new_state)
+
+        except PianoteqJsonRpcError as e:
+            logger.debug(f"Failed to get Pianoteq state: {e}")
+
+    def _notify_subscribers(self, state: PianoteqState) -> None:
+        """Notify all subscribers of state change."""
+        with self._callbacks_lock:
+            callbacks = self._callbacks.copy()
+
+        for callback in callbacks:
+            try:
+                callback(state)
+            except Exception as e:
+                logger.error(f"Error in state change callback: {e}")

--- a/tests/instrument/test_presets.py
+++ b/tests/instrument/test_presets.py
@@ -40,6 +40,39 @@ class PresetDisplayNameFieldTestCase(unittest.TestCase):
         self.assertEqual('Steel Drum natural', preset.display_name)
 
 
+class PresetModifiedStateTestCase(unittest.TestCase):
+    def test_preset_modified_defaults_to_false(self):
+        preset = Preset('Test Preset')
+        self.assertFalse(preset.modified)
+
+    def test_preset_modified_can_be_set_on_init(self):
+        preset = Preset('Test Preset', modified=True)
+        self.assertTrue(preset.modified)
+
+    def test_preset_modified_can_be_changed(self):
+        preset = Preset('Test Preset')
+        self.assertFalse(preset.modified)
+
+        preset.modified = True
+        self.assertTrue(preset.modified)
+
+    def test_get_display_name_with_modified_unmodified(self):
+        preset = Preset('Test Preset', display_name='Display Name', modified=False)
+        self.assertEqual('Display Name', preset.get_display_name_with_modified())
+
+    def test_get_display_name_with_modified_modified(self):
+        preset = Preset('Test Preset', display_name='Display Name', modified=True)
+        self.assertEqual('Display Name (modified)', preset.get_display_name_with_modified())
+
+    def test_get_display_name_with_modified_uses_display_name_not_name(self):
+        preset = Preset('Long Full Preset Name', display_name='Short', modified=True)
+        self.assertEqual('Short (modified)', preset.get_display_name_with_modified())
+
+    def test_get_display_name_with_modified_defaults_to_name(self):
+        preset = Preset('Test Preset', modified=True)
+        self.assertEqual('Test Preset (modified)', preset.get_display_name_with_modified())
+
+
 class LibraryFindPresetTestCase(unittest.TestCase):
     def setUp(self):
         inst1 = Instrument(i1, i1, '#000000', '#FFFFFF')

--- a/tests/lib/test_client_lib.py
+++ b/tests/lib/test_client_lib.py
@@ -7,6 +7,7 @@ from pi_pianoteq.instrument.selector import Selector
 from pi_pianoteq.instrument.instrument import Instrument
 from pi_pianoteq.instrument.preset import Preset
 from pi_pianoteq.rpc.types import PianoteqInfo, CurrentPreset
+from pi_pianoteq.state.state_monitor import PianoteqState
 
 
 class ClientLibPresetSyncTestCase(unittest.TestCase):
@@ -143,6 +144,184 @@ class ClientLibRandomizationTestCase(unittest.TestCase):
 
         self.jsonrpc.load_preset.assert_not_called()
         self.jsonrpc.randomize_parameters.assert_not_called()
+
+
+class ClientLibStateSyncTestCase(unittest.TestCase):
+    """Test state synchronization integration with StateMonitor."""
+
+    def setUp(self):
+        self.inst1 = Instrument('Steinway D', 'Steinway D', '#000000', '#FFFFFF')
+        self.preset1a = Preset('Steinway D Prelude', 'Prelude')
+        self.preset1b = Preset('Steinway D Jazz', 'Jazz')
+        self.inst1.presets = [self.preset1a, self.preset1b]
+
+        self.inst2 = Instrument('Ant. Petrof', 'Ant. Petrof', '#000000', '#FFFFFF')
+        self.preset2a = Preset('Ant. Petrof Recording 1', 'Recording 1')
+        self.inst2.presets = [self.preset2a]
+
+        self.library = Library([self.inst1, self.inst2])
+        self.selector = Selector([self.inst1, self.inst2])
+        self.jsonrpc = Mock()
+
+        # Default to first preset synced with modified=False
+        preset_info = CurrentPreset(name='Steinway D Prelude')
+        info = PianoteqInfo(current_preset=preset_info, modified=False)
+        self.jsonrpc.get_info.return_value = info
+
+    @patch('pi_pianoteq.lib.client_lib.StateMonitor')
+    def test_state_monitor_initialized_on_startup(self, mock_state_monitor_class):
+        """Test that StateMonitor is created and started on initialization."""
+        mock_monitor = Mock()
+        mock_state_monitor_class.return_value = mock_monitor
+
+        client_lib = ClientLib(self.library, self.selector, self.jsonrpc)
+
+        # StateMonitor should be created with correct parameters
+        mock_state_monitor_class.assert_called_once_with(self.jsonrpc, poll_interval=1.0)
+        # Should subscribe to state changes
+        mock_monitor.subscribe.assert_called_once()
+        # Should be started
+        mock_monitor.start.assert_called_once()
+
+    @patch('pi_pianoteq.lib.client_lib.StateMonitor')
+    def test_cleanup_stops_state_monitor(self, mock_state_monitor_class):
+        """Test that cleanup() stops the StateMonitor."""
+        mock_monitor = Mock()
+        mock_state_monitor_class.return_value = mock_monitor
+
+        client_lib = ClientLib(self.library, self.selector, self.jsonrpc)
+        client_lib.cleanup()
+
+        mock_monitor.stop.assert_called_once()
+
+    @patch('pi_pianoteq.lib.client_lib.StateMonitor')
+    def test_modified_flag_updated_on_initial_sync(self, mock_state_monitor_class):
+        """Test that initial sync updates the preset modified flag."""
+        mock_monitor = Mock()
+        mock_state_monitor_class.return_value = mock_monitor
+
+        # Set modified=True in Pianoteq
+        preset_info = CurrentPreset(name='Steinway D Prelude')
+        info = PianoteqInfo(current_preset=preset_info, modified=True)
+        self.jsonrpc.get_info.return_value = info
+
+        client_lib = ClientLib(self.library, self.selector, self.jsonrpc)
+
+        # Preset should have modified=True
+        current_preset = client_lib.get_current_preset()
+        self.assertTrue(current_preset.modified)
+
+    @patch('pi_pianoteq.lib.client_lib.StateMonitor')
+    def test_state_change_updates_modified_flag(self, mock_state_monitor_class):
+        """Test that state change callback updates modified flag."""
+        mock_monitor = Mock()
+        mock_state_monitor_class.return_value = mock_monitor
+
+        client_lib = ClientLib(self.library, self.selector, self.jsonrpc)
+
+        # Initially unmodified
+        current_preset = client_lib.get_current_preset()
+        self.assertFalse(current_preset.modified)
+
+        # Simulate state change with modified=True
+        new_state = PianoteqState(preset_name='Steinway D Prelude', modified=True)
+        client_lib._on_state_change(new_state)
+
+        # Modified flag should be updated
+        self.assertTrue(current_preset.modified)
+
+    @patch('pi_pianoteq.lib.client_lib.StateMonitor')
+    def test_state_change_with_different_preset_syncs_selection(self, mock_state_monitor_class):
+        """Test that external preset change syncs selector position."""
+        mock_monitor = Mock()
+        mock_state_monitor_class.return_value = mock_monitor
+
+        client_lib = ClientLib(self.library, self.selector, self.jsonrpc)
+
+        # Initially on first preset
+        self.assertEqual(0, self.selector.current_instrument_idx)
+        self.assertEqual(0, self.selector.current_instrument_preset_idx)
+
+        # Simulate external preset change to second instrument
+        new_state = PianoteqState(preset_name='Ant. Petrof Recording 1', modified=False)
+        client_lib._on_state_change(new_state)
+
+        # Selector should update to match
+        self.assertEqual(1, self.selector.current_instrument_idx)
+        self.assertEqual(0, self.selector.current_instrument_preset_idx)
+
+    @patch('pi_pianoteq.lib.client_lib.StateMonitor')
+    def test_state_change_with_unknown_preset_logs_warning(self, mock_state_monitor_class):
+        """Test that unknown external preset is logged but doesn't crash."""
+        mock_monitor = Mock()
+        mock_state_monitor_class.return_value = mock_monitor
+
+        client_lib = ClientLib(self.library, self.selector, self.jsonrpc)
+
+        # Simulate external preset change to unknown preset
+        new_state = PianoteqState(preset_name='Unknown Preset Not In Library', modified=False)
+
+        # Should not raise exception
+        client_lib._on_state_change(new_state)
+
+        # Selector should not change
+        self.assertEqual(0, self.selector.current_instrument_idx)
+
+    @patch('pi_pianoteq.lib.client_lib.StateMonitor')
+    def test_subscribe_to_state_changes_registers_callback(self, mock_state_monitor_class):
+        """Test that clients can subscribe to state changes."""
+        mock_monitor = Mock()
+        mock_state_monitor_class.return_value = mock_monitor
+
+        client_lib = ClientLib(self.library, self.selector, self.jsonrpc)
+
+        callback = Mock()
+        client_lib.subscribe_to_state_changes(callback)
+
+        self.assertIn(callback, client_lib._state_callbacks)
+
+    @patch('pi_pianoteq.lib.client_lib.StateMonitor')
+    def test_state_change_notifies_client_callbacks(self, mock_state_monitor_class):
+        """Test that state changes trigger client callbacks."""
+        mock_monitor = Mock()
+        mock_state_monitor_class.return_value = mock_monitor
+
+        client_lib = ClientLib(self.library, self.selector, self.jsonrpc)
+
+        callback = Mock()
+        client_lib.subscribe_to_state_changes(callback)
+
+        # Simulate state change
+        new_state = PianoteqState(preset_name='Steinway D Jazz', modified=True)
+        client_lib._on_state_change(new_state)
+
+        # Callback should be called with new state
+        callback.assert_called_once_with(new_state)
+
+    @patch('pi_pianoteq.lib.client_lib.StateMonitor')
+    def test_client_callback_exception_does_not_crash(self, mock_state_monitor_class):
+        """Test that exceptions in client callbacks are handled gracefully."""
+        mock_monitor = Mock()
+        mock_state_monitor_class.return_value = mock_monitor
+
+        client_lib = ClientLib(self.library, self.selector, self.jsonrpc)
+
+        # Register a callback that raises exception
+        bad_callback = Mock(side_effect=Exception("Callback error"))
+        good_callback = Mock()
+
+        client_lib.subscribe_to_state_changes(bad_callback)
+        client_lib.subscribe_to_state_changes(good_callback)
+
+        # Simulate state change
+        new_state = PianoteqState(preset_name='Steinway D Jazz', modified=True)
+
+        # Should not raise exception
+        client_lib._on_state_change(new_state)
+
+        # Both callbacks should be called despite exception
+        bad_callback.assert_called_once()
+        good_callback.assert_called_once()
 
 
 if __name__ == '__main__':

--- a/tests/state/__init__.py
+++ b/tests/state/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for state synchronization."""

--- a/tests/state/test_state_monitor.py
+++ b/tests/state/test_state_monitor.py
@@ -1,0 +1,242 @@
+"""Tests for StateMonitor class."""
+
+import unittest
+import time
+from unittest.mock import Mock, patch, MagicMock
+from pi_pianoteq.state.state_monitor import StateMonitor, PianoteqState
+from pi_pianoteq.rpc.jsonrpc_client import PianoteqJsonRpcError
+from pi_pianoteq.rpc.types import PianoteqInfo, CurrentPreset
+
+
+class TestStateMonitor(unittest.TestCase):
+    """Test StateMonitor polling and callback functionality."""
+
+    def setUp(self):
+        """Create mock JSON-RPC client."""
+        self.mock_jsonrpc = Mock()
+        self.monitor = StateMonitor(self.mock_jsonrpc, poll_interval=0.1)
+
+    def tearDown(self):
+        """Ensure monitor is stopped."""
+        if self.monitor._running:
+            self.monitor.stop()
+
+    def test_initial_state_is_none(self):
+        """Test that initial state is None before first poll."""
+        self.assertIsNone(self.monitor.get_current_state())
+
+    def test_subscribe_adds_callback(self):
+        """Test that subscribe adds callback to list."""
+        callback = Mock()
+        self.monitor.subscribe(callback)
+
+        self.assertIn(callback, self.monitor._callbacks)
+
+    def test_unsubscribe_removes_callback(self):
+        """Test that unsubscribe removes callback from list."""
+        callback = Mock()
+        self.monitor.subscribe(callback)
+        self.monitor.unsubscribe(callback)
+
+        self.assertNotIn(callback, self.monitor._callbacks)
+
+    def test_first_check_initializes_state_without_callback(self):
+        """Test that first state check sets state but doesn't call callbacks."""
+        callback = Mock()
+        self.monitor.subscribe(callback)
+
+        # Mock getInfo response
+        mock_info = PianoteqInfo(
+            current_preset=CurrentPreset(name="Test Preset"),
+            modified=False
+        )
+        self.mock_jsonrpc.get_info.return_value = mock_info
+
+        # Check state
+        self.monitor._check_state()
+
+        # State should be set
+        state = self.monitor.get_current_state()
+        self.assertIsNotNone(state)
+        self.assertEqual(state.preset_name, "Test Preset")
+        self.assertFalse(state.modified)
+
+        # Callback should not be called on first check
+        callback.assert_not_called()
+
+    def test_state_change_triggers_callback(self):
+        """Test that state change calls subscribed callbacks."""
+        callback = Mock()
+        self.monitor.subscribe(callback)
+
+        # Initial state
+        mock_info1 = PianoteqInfo(
+            current_preset=CurrentPreset(name="Preset 1"),
+            modified=False
+        )
+        self.mock_jsonrpc.get_info.return_value = mock_info1
+        self.monitor._check_state()
+
+        # Change state
+        mock_info2 = PianoteqInfo(
+            current_preset=CurrentPreset(name="Preset 2"),
+            modified=False
+        )
+        self.mock_jsonrpc.get_info.return_value = mock_info2
+        self.monitor._check_state()
+
+        # Callback should be called once with new state
+        callback.assert_called_once()
+        called_state = callback.call_args[0][0]
+        self.assertEqual(called_state.preset_name, "Preset 2")
+
+    def test_modified_flag_change_triggers_callback(self):
+        """Test that modified flag change alone triggers callback."""
+        callback = Mock()
+        self.monitor.subscribe(callback)
+
+        # Initial state
+        mock_info1 = PianoteqInfo(
+            current_preset=CurrentPreset(name="Test Preset"),
+            modified=False
+        )
+        self.mock_jsonrpc.get_info.return_value = mock_info1
+        self.monitor._check_state()
+
+        # Change only modified flag
+        mock_info2 = PianoteqInfo(
+            current_preset=CurrentPreset(name="Test Preset"),
+            modified=True
+        )
+        self.mock_jsonrpc.get_info.return_value = mock_info2
+        self.monitor._check_state()
+
+        # Callback should be called with modified=True
+        callback.assert_called_once()
+        called_state = callback.call_args[0][0]
+        self.assertTrue(called_state.modified)
+
+    def test_no_change_does_not_trigger_callback(self):
+        """Test that unchanged state doesn't trigger callbacks."""
+        callback = Mock()
+        self.monitor.subscribe(callback)
+
+        # Initial state
+        mock_info = PianoteqInfo(
+            current_preset=CurrentPreset(name="Test Preset"),
+            modified=False
+        )
+        self.mock_jsonrpc.get_info.return_value = mock_info
+
+        # Check twice with same state
+        self.monitor._check_state()
+        callback.reset_mock()
+        self.monitor._check_state()
+
+        # Callback should not be called second time
+        callback.assert_not_called()
+
+    def test_api_error_is_logged_not_raised(self):
+        """Test that API errors are logged but don't crash monitor."""
+        self.mock_jsonrpc.get_info.side_effect = PianoteqJsonRpcError("Connection failed")
+
+        # Should not raise exception
+        self.monitor._check_state()
+
+        # State should remain None
+        self.assertIsNone(self.monitor.get_current_state())
+
+    def test_callback_exception_is_logged(self):
+        """Test that callback exceptions are logged but don't stop other callbacks."""
+        callback1 = Mock(side_effect=Exception("Callback error"))
+        callback2 = Mock()
+
+        self.monitor.subscribe(callback1)
+        self.monitor.subscribe(callback2)
+
+        # Setup state change
+        mock_info1 = PianoteqInfo(
+            current_preset=CurrentPreset(name="Preset 1"),
+            modified=False
+        )
+        self.mock_jsonrpc.get_info.return_value = mock_info1
+        self.monitor._check_state()
+
+        mock_info2 = PianoteqInfo(
+            current_preset=CurrentPreset(name="Preset 2"),
+            modified=False
+        )
+        self.mock_jsonrpc.get_info.return_value = mock_info2
+
+        # Should not raise exception, both callbacks called
+        self.monitor._check_state()
+
+        callback1.assert_called_once()
+        callback2.assert_called_once()
+
+    def test_start_creates_thread(self):
+        """Test that start() creates and starts background thread."""
+        self.monitor.start()
+
+        self.assertTrue(self.monitor._running)
+        self.assertIsNotNone(self.monitor._thread)
+        self.assertTrue(self.monitor._thread.is_alive())
+
+        self.monitor.stop()
+
+    def test_stop_terminates_thread(self):
+        """Test that stop() terminates background thread."""
+        # Mock getInfo to prevent errors
+        self.mock_jsonrpc.get_info.return_value = PianoteqInfo(
+            current_preset=CurrentPreset(name="Test"),
+            modified=False
+        )
+
+        self.monitor.start()
+        self.assertTrue(self.monitor._running)
+
+        self.monitor.stop()
+        self.assertFalse(self.monitor._running)
+
+    def test_multiple_start_calls_ignored(self):
+        """Test that multiple start() calls don't create multiple threads."""
+        self.monitor.start()
+        thread1 = self.monitor._thread
+
+        self.monitor.start()
+        thread2 = self.monitor._thread
+
+        # Should be same thread
+        self.assertIs(thread1, thread2)
+
+        self.monitor.stop()
+
+    def test_stop_on_non_running_monitor(self):
+        """Test that stop() on non-running monitor is safe."""
+        # Should not raise exception
+        self.monitor.stop()
+        self.assertFalse(self.monitor._running)
+
+
+class TestPianoteqState(unittest.TestCase):
+    """Test PianoteqState dataclass."""
+
+    def test_state_creation(self):
+        """Test creating PianoteqState."""
+        state = PianoteqState(preset_name="Test Preset", modified=True)
+
+        self.assertEqual(state.preset_name, "Test Preset")
+        self.assertTrue(state.modified)
+
+    def test_state_equality(self):
+        """Test PianoteqState equality comparison."""
+        state1 = PianoteqState(preset_name="Test", modified=False)
+        state2 = PianoteqState(preset_name="Test", modified=False)
+        state3 = PianoteqState(preset_name="Test", modified=True)
+
+        self.assertEqual(state1, state2)
+        self.assertNotEqual(state1, state3)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Implements issue #65 by adding automatic state synchronization between Pianoteq and the application UI. The system detects when Pianoteq's state changes externally and updates the UI to reflect the correct state.

Key features:
- StateMonitor class polls Pianoteq's getInfo() API every 1 second
- Detects preset changes and modification state
- Callback system for notifying clients only when state actually changes
- Displays "(modified)" suffix when current preset has been modified
- Zero performance impact through efficient polling and change detection

Implementation details:
- Created state/state_monitor.py with thread-safe polling mechanism
- Updated Preset class to track modified flag
- Added get_display_name_with_modified() method to Preset
- Integrated StateMonitor into ClientLib with callback system
- Updated both GFX HAT and CLI clients to subscribe to state changes
- All clients now display preset modification status in real-time
- Proper cleanup on application exit

The state monitor runs in a background thread and only calls callbacks when actual state changes are detected, ensuring no negative performance implications.